### PR TITLE
Fix typos in argparse help

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--path", type=str, help="main path for tensorboard files", default=os.getcwd())
-    parser.add_argument("--subpaths", type=param_list, help="subpath structures", default=['test', 'train'])
+    parser.add_argument("--subpaths", type=param_list, help="subpath structures", default=['.'])
     parser.add_argument("--output", type=str, help="aggregation can be saved as tensorboard file (summary) or as table (csv)", default='summary')
 
     args = parser.parse_args()

--- a/aggregator.py
+++ b/aggregator.py
@@ -128,8 +128,8 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--path", type=str, help="main path for tensorboard files", default=os.getcwd())
-    parser.add_argument("--subpaths", type=param_list, help="subpath sturctures", default=['test', 'train'])
-    parser.add_argument("--output", type=str, help="aggregation can be saves as tensorboard file (summary) or as table (csv)", default='summary')
+    parser.add_argument("--subpaths", type=param_list, help="subpath structures", default=['test', 'train'])
+    parser.add_argument("--output", type=str, help="aggregation can be saved as tensorboard file (summary) or as table (csv)", default='summary')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
I'd also like to suggest changing the default `--subpath` from `['test', 'train']` to `['.']` as I believe the majority of users don't use subpaths. This came up in #2.